### PR TITLE
update to 1.0.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-ml-python" %}
-{% set version = "1.0.8" %}
+{% set version = "1.0.9" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 19ffc62421acc321f350a6daef0808ad4da7dd8bb2560964cda2559020124295
+  sha256: 4392b5a32fbca71fd97f351eb5ff30bda34f4f75a3ff3c5a7ec32bb3ba9d001a
 
 build:
   number: 0
@@ -51,8 +51,10 @@ requirements:
     - sqlparse >=0.4,<1
     - typing-extensions >=4.1.0,<5
     - xgboost >=1.7.3,<2
+    - cachetools >=3.1.1,<5
   run_constrained:
     - lightgbm ==3.3.5
+    - shap ==0.42.1
     - mlflow >=2.1.0,<2.4
     - sentencepiece >=0.1.95,<0.2
     - tensorflow >=2.9,<3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,6 @@ requirements:
     - wheel
   run:
     - absl-py >=0.15,<2
-    - aiohttp !=4.0.0a0,!=4.0.0a1
     - anyio >=3.5.0,<4
     - cloudpickle
     - fsspec >=2022.11,<2024


### PR DESCRIPTION
update snowflake-ml-python to 1.0.9
[requirements](https://github.com/snowflakedb/snowflake-ml-python/blob/1.0.9/requirements.yml)

added  to run:
- cachetools >=3.1.1,<5
 
added to run_constrained:
- shap ==0.42.1
 
removed from run:
- aiohttp !=4.0.0a0,!=4.0.0a1  -as it is s3fs dependency
