### PR TITLE
update to 1.0.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-ml-python" %}
-{% set version = "1.0.10" %}
+{% set version = "1.0.11" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 39dd904e899a0c93a974a480cff75618e096232d40fc630a9b52b37050725a33
+  sha256: 6f8c2d55122eec0541b30d32c41bca59db3e36685828f83b98ec33a832a082f3
 
 build:
   number: 0
@@ -57,7 +57,7 @@ requirements:
     - shap ==0.42.1
     - mlflow >=2.1.0,<2.4
     - sentencepiece >=0.1.95,<0.2
-    - tensorflow >=2.9,<3
+    - tensorflow >=2.9,<3,!=2.12.0
     - tokenizers>=0.10,<1
     - torchdata >=0.4,<1
     - transformers >=4.29.2,<5


### PR DESCRIPTION
update snowflake-ml-python to 1.0.11

- [upstream])(https://github.com/snowflakedb/snowflake-ml-python/tree/1.0.11)
- [peft](https://github.com/snowflakedb/snowflake-ml-python/blob/73c2cf0003a3741e00300a9a23507fa28d59e6c5/requirements.yml#L268C18-L268C18) requirement only on pypi, as it was outdated at CF, still want to have it in future
- [tensorflow](https://github.com/snowflakedb/snowflake-ml-python/blob/73c2cf0003a3741e00300a9a23507fa28d59e6c5/requirements.yml#L220) version updated