### PR TITLE
update to 1.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-ml-python" %}
-{% set version = "1.1.0" %}
+{% set version = "1.1.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 8942c91412341b5047a98637e563a68bc8d378b0705b35f14755026b2f0f831d
+  sha256: 7c40b407b93e413496eb915362840ebfe738afbc97714af7c959899c5fafd70f
 
 build:
   number: 0
@@ -39,11 +39,13 @@ requirements:
     - numpy >=1.23,<2
     - packaging >=20.9,<24
     - pandas >=1.0.0,<2
+    - pyarrow
     - pytimeparse >=1.1.8,<2
     - python
     - pyyaml >=6.0,<7
     # requests is an extra dependency for fsspec[http]
     - requests
+    - retrying >=1.3.3,<2
     - s3fs >=2022.11,<2024
     - scikit-learn >=1.2.1,<1.4
     - scipy >=1.9,<2


### PR DESCRIPTION
snowflake-ml-python 1.1.2 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3690](https://anaconda.atlassian.net/browse/PKG-3690) 
- [Upstream repository](https://github.com/snowflakedb/snowflake-ml-python/blob/1.1.2/)
- [diff](https://github.com/snowflakedb/snowflake-ml-python/compare/1.1.1...1.1.2)

### Explanation of changes:

-  update to 1.1.2
-  added pyarrrow run time dependency
-  added retrying >=1.3.3,<2  run time dependency


[PKG-3690]: https://anaconda.atlassian.net/browse/PKG-3690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ