### PR TITLE
snowflake-ml-python 1.5.0 Fix: remove kill java, fix zombie java [skip-ci]

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,7 +15,8 @@ bazel "--output_user_root=C:\broot" --max_idle_secs=1 "build" "--repository_cach
 @REM removes the entire output base tree which, in addition to the 
 @REM build output, contains all temp files created by Bazel. 
 @REM NB: It also stops the Bazel server after the clean, equivalent 
-@REM to the shutdown command.
+@REM to the shutdown command. Nevertheless, if we do not run also
+@REM the "bazel shutdown", the next build will fail for some reason.
 @REM 
 @REM See: https://bazel.build/docs/user-manual#clean
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,18 +2,29 @@
 setlocal EnableDelayedExpansion
 
 @REM max_idle_secs=1 will make the idle server to shutdown after 1 second
-@REM that is idle
+@REM that is idle, after the command "bazel shutdown".
+@REM 
+@REM Please do NOT remove it, see comment below about "bazel shutdown"
+
 bazel "--output_user_root=C:\broot" --max_idle_secs=1 "build" "--repository_cache=" "--nobuild_python_zip" "--enable_runfiles" --action_env="USERPROFILE=%USERPROFILE%" --host_action_env="USERPROFILE=%USERPROFILE%" ":wheel"
+
+@REM build
+
 %PYTHON% -m pip install -vv --no-deps --no-build-isolation  bazel-bin\dist\snowflake_ml_python-%PKG_VERSION%-py3-none-any.whl
 
 @REM removes the entire output base tree which, in addition to the 
 @REM build output, contains all temp files created by Bazel. 
 @REM NB: It also stops the Bazel server after the clean, equivalent 
 @REM to the shutdown command.
-@REM See: https://bazel.build/docs/user-manual#clean
 @REM 
-@REM Do NOT run "bazel shutdown" after
-@REM this, or it will create a zombie java.exe holding some handles
-@REM that prevent conda-build to delete/move/rename certain folders 
-@REM and files (e.g. work, and temporary).
-bazel "clean" "--expunge"
+@REM See: https://bazel.build/docs/user-manual#clean
+
+bazel clean --expunge
+
+@REM The command "bazel shutdown" will create a zombie java.exe holding
+@REM some handles that prevent conda-build to delete/move/rename certain
+@REM folders and files (e.g. work, and temporary).
+@REM For this reason, the parameter max_idle_secs=1 in the bazel build
+@REM is essential and it should NOT be removed.
+
+bazel shutdown

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,13 +1,16 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-bazel "--output_user_root=C:\broot" "build" "--repository_cache=" "--nobuild_python_zip" "--enable_runfiles" --action_env="USERPROFILE=%USERPROFILE%" --host_action_env="USERPROFILE=%USERPROFILE%" ":wheel"
+@REM max_idle_secs=1 will make the idle server to shutdown after 1 second
+@REM that is idle
+bazel "--output_user_root=C:\broot" --max_idle_secs=1 "build" "--repository_cache=" "--nobuild_python_zip" "--enable_runfiles" --action_env="USERPROFILE=%USERPROFILE%" --host_action_env="USERPROFILE=%USERPROFILE%" ":wheel"
 %PYTHON% -m pip install -vv --no-deps --no-build-isolation  bazel-bin\dist\snowflake_ml_python-%PKG_VERSION%-py3-none-any.whl
-bazel "clean" "--expunge"
-bazel "shutdown"
 
-@REM Some handles are hold by java.exe/micromamba, and prevent conda-build to
-@REM delete/move/rename certain folders and files (e.g. work, and temporary).
-@REM Killing java.exe serves to release such handles and allow conda-build
-@REM to progress with the next builds for different python versions.
-taskkill /IM "java.exe" /F
+@REM removes the entire output base tree which, in addition to the 
+@REM build output, contains all temp files created by Bazel. 
+@REM NB: It also stops the Bazel server after the clean, equivalent 
+@REM to the shutdown command -> do NOT run "bazel shutdown" after
+@REM this, or it will create a zombie java.exe holding some handles
+@REM that prevent conda-build to delete/move/rename certain folders 
+@REM and files (e.g. work, and temporary).
+bazel "clean" "--expunge"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,7 +9,10 @@ bazel "--output_user_root=C:\broot" --max_idle_secs=1 "build" "--repository_cach
 @REM removes the entire output base tree which, in addition to the 
 @REM build output, contains all temp files created by Bazel. 
 @REM NB: It also stops the Bazel server after the clean, equivalent 
-@REM to the shutdown command -> do NOT run "bazel shutdown" after
+@REM to the shutdown command.
+@REM See: https://bazel.build/docs/user-manual#clean
+@REM 
+@REM Do NOT run "bazel shutdown" after
 @REM this, or it will create a zombie java.exe holding some handles
 @REM that prevent conda-build to delete/move/rename certain folders 
 @REM and files (e.g. work, and temporary).

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,7 @@ if [ "$(uname)" == "Linux" ]; then
 fi
 
 # Build the wheel.
-bazel build --subcommands //:wheel
+bazel --max_idle_secs=1 build --subcommands //:wheel
 
 # Install it.
 ${PYTHON} -m pip install -vv --no-deps --no-build-isolation bazel-bin/dist/snowflake_ml_python-$PKG_VERSION-py3-none-any.whl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 84ac8143871bf827454437b1db951e2b4a1d09d76c32c3e2d500c5ef4ad2b711
 
 build:
-  number: 0
+  number: 1
   skip: True # [py<38 or py>311]
   # bazel not available on s390x
   skip: True # [s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 84ac8143871bf827454437b1db951e2b4a1d09d76c32c3e2d500c5ef4ad2b711
 
 build:
-  number: 1
+  number: 0
   skip: True # [py<38 or py>311]
   # bazel not available on s390x
   skip: True # [s390x]


### PR DESCRIPTION
snowflake-ml-python 1.5.0

**Destination channel:** defaults

### Links

- no ticket
- see previous PR #28 where a `taskkill /IM "java.exe" /F` was executed to kill a zombie `java.exe` process, created after the command `bazel shutdown`, and which was holding some handles that prevented conda-build to delete/move/rename certain folders and files (e.g. work, and temporary).

### Explanation of changes:

- Fix: remove kill java, fix zombie java: add `--max_idle_secs=1` to let the idle process exit.
