### PR TITLE
snowflake-ml-python 1.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-ml-python" %}
-{% set version = "1.5.0" %}
+{% set version = "1.5.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 84ac8143871bf827454437b1db951e2b4a1d09d76c32c3e2d500c5ef4ad2b711
+  sha256: 9bbd816d3a7950391ecb79605236dc0e5082ab9f32e966ee46760768adc01c50
 
 build:
   number: 0
@@ -52,7 +52,6 @@ requirements:
     - aiohttp !=4.0.0a0,!=4.0.0a1
     - anyio >=3.5.0,<4
     - cachetools >=3.1.1,<6
-    - catboost >=1.2.0,<1.3
     - cloudpickle >=2.0.0
     - fsspec >=2022.11,<2024
     # requests is an extra dependency for fsspec[http]
@@ -74,34 +73,20 @@ requirements:
     - typing-extensions >=4.1.0,<5
     - xgboost >=1.7.3,<2
   run_constrained:
-    # Seems to be optional
+    - catboost >=1.2.0,<2
+    - lightgbm >=3.3.5,<5
+    - mlflow >=2.1.0,<2.4
+    - pytorch >=2.0.1,<3
+    - sentence-transformers >=2.2.2,<3
+    - sentencepiece >=0.1.95,<1
     - shap ==0.42.1
-    # Seems to be optional to LLM although not explicitly used. Also, not sure if pip will install it.
-    - sentencepiece >=0.1.95,<0.2
-    # Seems to be optional depending on task executed within huggingface pipeline, but it's listed as part of transformers.
-    # Also, not sure if pip will install it, also there is inconsistency as far as range requirement. (less restrictive one seems to be >=0.10,<1)
+    - tensorflow >=2.10,<3
     - tokenizers >=0.10,<1
-    # these dependencies are specified as optional and also in a run_contrained section of their recipe
-    # but in reality they may always be imported, hence they should be specified in the run section
-    # ...
+    - torchdata >=0.4,<1
+    - transformers >=4.32.1,<5
     # seems to be imported when LLM is used
     # we don't have this on defaults or other channels
     - peft >=0.5.0,<1
-    # seems to be required by one specific model specification builder
-    - lightgbm >=3.3.5,<4.2
-    # seems to be required by one specific model handler
-    - mlflow >=2.1.0,<2.4
-    # seems to be required in multiple places, especially LLM which seems to be included, also on all platforms, not just win
-    - pytorch >=2.0.1,<3
-    # seems to be required in multiple places
-    # requiring this as a run dependency seems to cause a lot of dependency problems.
-    - tensorflow >=2.10,<3
-    # Seems to be depepndent on pytorch, so not optional
-    - torchdata >=0.4,<1
-    # seems to be in multiple places, especially LLM which seems to be included
-    - transformers >=4.32.1,<5
-    # seems to be required by one specific model handler
-    - sentence-transformers >=2.2.2,<3
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,19 +74,34 @@ requirements:
     - xgboost >=1.7.3,<2
   run_constrained:
     - catboost >=1.2.0,<2
-    - lightgbm >=3.3.5,<5
-    - mlflow >=2.1.0,<2.4
-    - pytorch >=2.0.1,<3
-    - sentence-transformers >=2.2.2,<3
-    - sentencepiece >=0.1.95,<1
+    # Seems to be optional
     - shap ==0.42.1
-    - tensorflow >=2.10,<3
+    # Seems to be optional to LLM although not explicitly used. Also, not sure if pip will install it.
+    - sentencepiece >=0.1.95,<1
+    # Seems to be optional depending on task executed within huggingface pipeline, but it's listed as part of transformers.
+    # Also, not sure if pip will install it, also there is inconsistency as far as range requirement. (less restrictive one seems to be >=0.10,<1)
     - tokenizers >=0.10,<1
-    - torchdata >=0.4,<1
-    - transformers >=4.32.1,<5
+    # these dependencies are specified as optional and also in a run_contrained section of their recipe
+    # but in reality they may always be imported, hence they should be specified in the run section
+    # ...
     # seems to be imported when LLM is used
     # we don't have this on defaults or other channels
     - peft >=0.5.0,<1
+    # seems to be required by one specific model specification builder
+    - lightgbm >=3.3.5,<5
+    # seems to be required by one specific model handler
+    - mlflow >=2.1.0,<2.4
+    # seems to be required in multiple places, especially LLM which seems to be included, also on all platforms, not just win
+    - pytorch >=2.0.1,<3
+    # seems to be required in multiple places
+    # requiring this as a run dependency seems to cause a lot of dependency problems.
+    - tensorflow >=2.10,<3
+    # Seems to be depepndent on pytorch, so not optional
+    - torchdata >=0.4,<1
+    # seems to be in multiple places, especially LLM which seems to be included
+    - transformers >=4.32.1,<5
+    # seems to be required by one specific model handler
+    - sentence-transformers >=2.2.2,<3
 
 test:
   imports:


### PR DESCRIPTION
snowflake-ml-python 1.5.1

**Destination channel:** defaults

### Links

- [PKG-4853]
- dev_url (pypi): https://github.com/snowflakedb/snowflake-ml-python/tree/1.5.1
- diff [1.5.0...1.5.1](https://github.com/snowflakedb/snowflake-ml-python/compare/1.5.0...1.5.1): https://github.com/snowflakedb/snowflake-ml-python/compare/1.5.0...1.5.1

- conda-forge: _feedstock not found on conda-forge_

- pypi: https://pypi.org/project/snowflake-ml-python/1.5.1
- pypi inspector: https://inspector.pypi.io/project/snowflake-ml-python/1.5.1

### Explanation of changes:

- bump to `1.5.1`.
- update pinnings and dependencies (`catboost >=1.2.0,<2` updated and moved from `run` to `run_constrained`).
- clean up recipe from comments in the `run_constrained`.

### Notes for Reviewers

- For the `run` and `run_constrained` dependencies, please have a look at the diff [1.5.0...1.5.1](https://github.com/snowflakedb/snowflake-ml-python/compare/1.5.0...1.5.1) and the `requirements.yml` and `ci/conda_recipe/meta.yaml` files.

[PKG-4853]: https://anaconda.atlassian.net/browse/PKG-4853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ