### PR TITLE
snowflake-ml-python 1.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-ml-python" %}
-{% set version = "1.5.1" %}
+{% set version = "1.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 9bbd816d3a7950391ecb79605236dc0e5082ab9f32e966ee46760768adc01c50
+  sha256: 7bb7a3cd41ccc49bb25e4efa3add1f32ca33b6d1e462d288adea4c182366ee2a
 
 build:
   number: 0


### PR DESCRIPTION
snowflake-ml-python 1.5.2

**Destination channel:** defaults

### Links

- [PKG-5071]
- dev_url (pypi): https://github.com/snowflakedb/snowflake-ml-python/tree/1.5.2
- [1.5.1...1.5.2](https://github.com/snowflakedb/snowflake-ml-python/compare/1.5.1...1.5.2) diff: https://github.com/snowflakedb/snowflake-ml-python/compare/1.5.1...1.5.2
- conda-forge: _feedstock not found on conda-forge_
- pypi: https://pypi.org/project/snowflake-ml-python/1.5.2
- pypi inspector: https://inspector.pypi.io/project/snowflake-ml-python/1.5.2

### Explanation of changes:

- bump version, no changes in dependencies


[PKG-5071]: https://anaconda.atlassian.net/browse/PKG-5071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ