### PR TITLE
[PKG-5611] snowflake-ml-python 1.6.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @AnacondaRecipes/psubs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,9 @@ source:
   sha256: 320325d96abeda1b2b8fc359d5bd7d54a73b366ebd03129c4a6332f843efd95c
 
 build:
-  number: 0
+  # allows SF to rebuild the package as needed without incurring a
+  # higher build number than the package we release
+  number: 100
   skip: True # [py<38 or py>311]
   # bazel not available on s390x
   skip: True # [s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-ml-python" %}
-{% set version = "1.6.1" %}
+{% set version = "1.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: a1bc42e3786b7c4b55e8f9a00c4d3b80568cb0932f89b8a76d044279fe9b71a6
+  sha256: 320325d96abeda1b2b8fc359d5bd7d54a73b366ebd03129c4a6332f843efd95c
 
 build:
   number: 0


### PR DESCRIPTION
snowflake-ml-python 1.6.0

**Destination channel:** defaults

### Links

- [PKG-5611](https://anaconda.atlassian.net/browse/PKG-5611) 
- [Upstream repository](https://github.com/snowflakedb/snowflake-ml-python/tree/1.6.0)
- [Upstream changelog/diff](https://github.com/snowflakedb/snowflake-ml-python/compare/1.6.0...1.6.1)

### Explanation of changes:

- build 1.6.0
- changed build number to 100


[PKG-5611]: https://anaconda.atlassian.net/browse/PKG-5611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ