### PR TITLE
snowflake-ml-python 1.6.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,11 +38,10 @@ requirements:
     - git         # [not win]
     # Bazel has rules to run Miniconda to build the package so make sure that the Miniconda and conda-libmamba-solver versions are correct, 
     # because it can affect the build process, see https://github.com/snowflakedb/snowflake-ml-python/blob/main/third_party/rules_conda/conda.bzl
-    # only for version 1.6.3 while we fix bazel 6.5.0 for win, we use the previous version
-    #- bazel 6.2.0         # [win]
+    # only for version 1.6.4 while we fix bazel 6.5.0 for win, we use the previous version
+    - bazel 6.2.0         # [win]
     # upstream uses ==6.3.0 but we have 6.2.0 or 6.5.0
-    #- bazel 6.5.0         # [not win]
-    - bazel 6.5.0
+    - bazel 6.5.0         # [not win]
     - {{ compiler('c') }}
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,7 +100,7 @@ test:
     - pip
   commands:
     # On win-64 this does not pick up xgboost for some reason, so skip it.
-    - pip check   # [not win]
+    - pip check
 
 about:
   home: https://github.com/snowflakedb/snowflake-ml-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -99,7 +99,6 @@ test:
   requires:
     - pip
   commands:
-    # On win-64 this does not pick up xgboost for some reason, so skip it.
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-ml-python" %}
-{% set version = "1.6.3" %}
+{% set version = "1.6.4" %}
 
 package:
   name: {{ name|lower }}
@@ -39,9 +39,10 @@ requirements:
     # Bazel has rules to run Miniconda to build the package so make sure that the Miniconda and conda-libmamba-solver versions are correct, 
     # because it can affect the build process, see https://github.com/snowflakedb/snowflake-ml-python/blob/main/third_party/rules_conda/conda.bzl
     # only for version 1.6.3 while we fix bazel 6.5.0 for win, we use the previous version
-    - bazel 6.2.0         # [win]
+    #- bazel 6.2.0         # [win]
     # upstream uses ==6.3.0 but we have 6.2.0 or 6.5.0
-    - bazel 6.5.0         # [not win]
+    #- bazel 6.5.0         # [not win]
+    - bazel 6.5.0
     - {{ compiler('c') }}
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: d5080496ecc00d7070061990f9792567d7b0b18003b4c396aa16c85fd311b5dc
+  sha256: 9827773aebf99b569bddccf01ad8db072477867c2fc2278fdabd61b8d6c45ca4
 
 build:
   # The build number of this package should always start from 100


### PR DESCRIPTION
snowflake-ml-python 1.6.4

**Destination channel:** defaults

### Links

- [PKG-5973](https://anaconda.atlassian.net/browse/PKG-5973) 
- [Upstream repository](https://github.com/snowflakedb/snowflake-ml-python/tree/1.6.4)

### Explanation of changes:

- Upgrade to v1.6.4
- Keeping the `win` workaround for `bazel 6.5.0` as it is still broken.
- Restored pip check on Windows.


[PKG-5973]: https://anaconda.atlassian.net/browse/PKG-5973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ